### PR TITLE
Add dockerization for all PDO drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ git checkout pdo_sub_classing
 make install -j8
 
 php run-tests.php \
+  ext/pdo \
   ext/pdo_mysql \
   ext/pdo_pgsql \
   ext/pdo_sqlite \
@@ -38,9 +39,6 @@ php run-tests.php \
   ext/pdo_firebird \
   ext/pdo_oci \
   ext/pdo_odbc
-
-# PDOTEST_DSN is not set globally as it would override DSNs for other tests
-PDOTEST_DSN="sqlite::memory:" php run-tests.php ext/pdo
 
 psql "sslmode=disable dbname=phptest user=postgresuser host=host.docker.internal"
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,15 @@ git checkout pdo_sub_classing
 
 make install -j8
 
-php run-tests.php ext/pdo ext/pdo_mysql/ ext/pdo_pgsql/ ext/pdo_sqlite/
-
+php run-tests.php \
+  ext/pdo \
+  ext/pdo_mysql \
+  ext/pdo_pgsql \
+  ext/pdo_sqlite \
+  ext/pdo_dblib \
+  ext/pdo_firebird \
+  ext/pdo_oci \
+  ext/pdo_odbc
 
 psql "sslmode=disable dbname=phptest user=postgresuser host=host.docker.internal"
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ git checkout pdo_sub_classing
 make install -j8
 
 php run-tests.php \
-  ext/pdo \
   ext/pdo_mysql \
   ext/pdo_pgsql \
   ext/pdo_sqlite \
@@ -39,6 +38,9 @@ php run-tests.php \
   ext/pdo_firebird \
   ext/pdo_oci \
   ext/pdo_odbc
+
+# PDOTEST_DSN is not set globally as it would override DSNs for other tests
+PDOTEST_DSN="sqlite::memory:" php run-tests.php ext/pdo
 
 psql "sslmode=disable dbname=phptest user=postgresuser host=host.docker.internal"
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,11 @@ git checkout pdo_sub_classing
   --with-curl \
   --with-pdo-mysql \
   --with-pdo-pgsql \
-  --with-pdo-sqlite
-
+  --with-pdo-sqlite \
+  --with-pdo-dblib \
+  --with-pdo-firebird \
+  --with-pdo-oci=instantclient,/opt/oracle/instantclient \
+  --with-pdo-odbc=unixODBC,/usr
 
 make install -j8
 

--- a/containers/developing/Dockerfile
+++ b/containers/developing/Dockerfile
@@ -11,7 +11,39 @@ RUN apt-get update -qq \
     libonig-dev  libcurl4-openssl-dev libwebp-dev vim \
     strace valgrind libtiff5-dev libfftw3-dev libde265-dev libheif-dev \
     libssl-dev libzip-dev unzip libpq-dev mycli libsqlite3-dev libsqlite3-mod-spatialite \
-    inetutils-ping postgresql-contrib
+    inetutils-ping postgresql-contrib \
+    # PDO_DBLIB dependencies
+    freetds-dev freetds-bin \
+    # PDO_ODBC dependencies
+    unixodbc-dev \
+    # Needed to set up MySQL's ODBC packages
+    dpkg-dev \
+    # PDO_FIREBIRD dependencies
+    firebird-dev \
+    # PDO_OCI dependencies
+    libaio1
+
+# Install ODBC connector for MySQL
+RUN set -eux; \
+    cd /tmp; \
+    wget https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-community-client-plugins_8.0.33-1debian11_amd64.deb; \
+    wget https://dev.mysql.com/get/Downloads/Connector-ODBC/8.0/mysql-connector-odbc_8.0.33-1debian11_amd64.deb; \
+    dpkg -i mysql-community-client-plugins_8.0.33-1debian11_amd64.deb; \
+    dpkg -i mysql-connector-odbc_8.0.33-1debian11_amd64.deb; \
+    rm mysql-community-client-plugins_8.0.33-1debian11_amd64.deb; \
+    rm mysql-connector-odbc_8.0.33-1debian11_amd64.deb;
+
+# Install Oracle client SDK
+RUN set -eux; \
+    mkdir -p /opt/oracle; \
+    cd /opt/oracle; \
+    wget https://download.oracle.com/otn_software/linux/instantclient/2110000/instantclient-basic-linux.x64-21.10.0.0.0dbru.zip; \
+    wget https://download.oracle.com/otn_software/linux/instantclient/2110000/instantclient-sdk-linux.x64-21.10.0.0.0dbru.zip; \
+    unzip instantclient-basic-linux.x64-21.10.0.0.0dbru.zip; \
+    unzip instantclient-sdk-linux.x64-21.10.0.0.0dbru.zip; \
+    echo /opt/oracle/instantclient_21_10 > /etc/ld.so.conf.d/oracle-instantclient.conf; \
+    ln -s /opt/oracle/instantclient_21_10 /opt/oracle/instantclient; \
+    ldconfig;
 
 # Make the default directory a useful one
 WORKDIR /var/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@ services:
     volumes:
       - .:/var/app
     environment:
-      REDIR_TEST_DIR: /var/app/php-src/ext/pdo/tests/
       PDO_MYSQL_TEST_DSN: mysql:host=host.docker.internal;port=3306;dbname=mysqluser
       PDO_MYSQL_TEST_USER: mysqluser
       PDO_MYSQL_TEST_PASS: pass12345

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,24 @@ services:
       PDO_MYSQL_TEST_USER: mysqluser
       PDO_MYSQL_TEST_PASS: pass12345
       PDO_PGSQL_TEST_DSN: pgsql:host=host.docker.internal;port=5432;dbname=phptest;user=postgresuser;password=pass12345
- # firebird:
- #   image: jacobalberty/firebird:v3.0.10
+      PDO_DBLIB_TEST_DSN: dblib:host=mssql;dbname=master
+      PDO_DBLIB_TEST_USER: SA
+      PDO_DBLIB_TEST_PASS: MyPass123
+      PDO_FIREBIRD_TEST_DSN: firebird:dbname=firebird/3050:/firebird/data/testdb
+      PDO_FIREBIRD_TEST_USER: testuser
+      PDO_FIREBIRD_TEST_PASS: MyPass123
+      PDO_OCI_TEST_DSN: >
+        oci:dbname=(DESCRIPTION =
+          (ADDRESS_LIST = (ADDRESS = (PROTOCOL = TCP)(HOST = oracle)(PORT = 1521)))
+          (CONNECT_DATA = (SERVICE_NAME = XEPDB1))
+        )
+      PDO_OCI_TEST_USER: testuser
+      PDO_OCI_TEST_PASS: MyPass123
+      PDO_ODBC_TEST_DSN: odbc:driver=MySQL ODBC 8.0 Unicode Driver;server=mysql;database=mysqluser
+      PDO_ODBC_TEST_USER: mysqluser
+      PDO_ODBC_TEST_PASS: pass12345
+
+  # Used for PDO_MYSQL and PDO_ODBC tests
   mysql:
     image: mysql:8.0.30
     command: --default-authentication-plugin=mysql_native_password
@@ -28,6 +44,8 @@ services:
       - ./containers/mysql/config/my.cnf:/etc/mysql/my.cnf
       - ./data/mysql:/var/lib/mysql
       - .:/var/app
+
+  # Used for PDO_PGSQL tests
   postgres:
     image: postgres:14.7
     environment:
@@ -36,6 +54,31 @@ services:
       POSTGRES_DB: phptest
     ports:
       - 5432:5432
+
+  # Used for PDO_DBLIB tests
+  mssql:
+    image: mcr.microsoft.com/mssql/server
+    environment:
+      ACCEPT_EULA: Y
+      # SQL Server has PW complexity requirements
+      SA_PASSWORD: MyPass123
+
+  # Used for PDO_OCI tests
+  oracle:
+    image: gvenzl/oracle-xe
+    environment:
+      ORACLE_RANDOM_PASSWORD: true
+      APP_USER: testuser
+      APP_USER_PASSWORD: MyPass123
+
+  # Used for PDO_FIREBIRD tests
+  firebird:
+    image: jacobalberty/firebird
+    environment:
+      FIREBIRD_DATABASE: testdb
+      FIREBIRD_USER: testuser
+      FIREBIRD_PASSWORD: MyPass123
+
 networks:
   default_network:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     volumes:
       - .:/var/app
     environment:
+      REDIR_TEST_DIR: /var/app/php-src/ext/pdo/tests/
       PDO_MYSQL_TEST_DSN: mysql:host=host.docker.internal;port=3306;dbname=mysqluser
       PDO_MYSQL_TEST_USER: mysqluser
       PDO_MYSQL_TEST_PASS: pass12345

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,8 +38,6 @@ services:
       MYSQL_ROOT_HOST: "%"
     ports:
       - 3306:3306
-    networks:
-      default_network:
     volumes:
       - ./containers/mysql/config/my.cnf:/etc/mysql/my.cnf
       - ./data/mysql:/var/lib/mysql
@@ -78,7 +76,3 @@ services:
       FIREBIRD_DATABASE: testdb
       FIREBIRD_USER: testuser
       FIREBIRD_PASSWORD: MyPass123
-
-networks:
-  default_network:
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
   # Used for PDO_MYSQL and PDO_ODBC tests
   mysql:
     image: mysql:8.0.30
-    command: --default-authentication-plugin=mysql_native_password
+    command: --default-authentication-plugin=mysql_native_password --log-bin-trust-function-creators=true
     environment:
       MYSQL_ROOT_PASSWORD: pass12345
       MYSQL_DATABASE: mysqluser


### PR DESCRIPTION
Adds setup and testing setup for these extensions:

- `PDO_DBLIB` (using MS SQL Server for tests)
- `PDO_FIREBIRD`
- `PDO_OCI`
- `PDO_ODBC` (using MySQL for tests)

Besides I removed `mysql`'s network in the compose file so it would join the default network with the other containers and would be accessible from the `developing` container. Previously it was only accessed via the port mapped to host, but internal communication should be more straightforward here.

Currently some of the tests do not pass, I am not (yet) sure if any of that (apart from pdo skips) is related to the setup. Here are the test stats in the current state:

| Suite        | Tests | Skipped | Warned | Failed | Failed (exp) | Passed |
|--------------|-------|---------|--------|--------|--------------|--------|
| PDO          | 83    | 77      | 0      | 0      | 1            | 6      |
| PDO_DBLIB    | 109   | 2       | 0      | 1      | 1            | 105    |
| PDO_FIREBIRD | 108   | 11      | 0      | 7      | 1            | 89     |
| PDO_MSYQL    | 231   | 12      | 0      | 2      | 1            | 216    |
| PDO_OCI      | 120   | 14      | 0      | 9      | 1            | 96     |
| PDO_ODBC     | 90    | 6       | 0      | 7      | 1            | 76     |
| PDO_PGSQL    | 123   | 6       | 0      | 0      | 1            | 116    |
| PDO_SQLITE   | 128   | 5       | 0      | 0      | 1            | 122    |

Why do tests fail?

- PDO_DBLIB test is wrong (does not support this TDS version)
- PDO_FIREBIRD 1 test (pdo_039) is wrong, 3 tests (pdo_007, pdo_008, pdo_033) fail because of firebird's value [padding](https://stackoverflow.com/questions/54657441/when-use-charset-parameter-pdo-fetchs-blank-spaces-in-fields), 1 test (bug 76452) segfaults likely because it tries to use a local db, 2 are [fixed on upstream](https://github.com/php/php-src/commit/e86acb18616a06f86069392893fe59a2bb7920fb)
- PDO_MYSQL: dunno, looks like setting charset in DSN should work, but it doesn't
- PDO_OCI: [2 fixed](https://github.com/php/php-src/commit/2db2cab6adb95707e3bf671d8e6c3c19623c64c3#diff-40187b67d6706c10bf1df694f2ecfaa1186807888e6c2c7e2e8c2f6119cc570bR34-R36) on upstream, [2 xfailed](https://github.com/php/php-src/commit/305892580efc063fb3c2ddfb4c8d254c7d1ffb5c) on upstream, the others are intended to run as admin, ignoring here
- PDO_ODBC: tests are written in T-SQL and some fail on MySQL, ignore